### PR TITLE
Update request headers to fix 404

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,9 +19,10 @@ def fetch_and_create_deck():
         return
 
     headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3.1 Safari/605.1.15",
         "Accept-Language": "en-US,en;q=0.9",
-        "Accept-Encoding": "gzip, deflate, br",
+	"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Encoding": "gzip, deflate, br, zstd",
         "Connection": "keep-alive",
     }
 


### PR DESCRIPTION
It seems Brainscape has blocked or updated the requirements for requesting the page containing the flashcards, blocking this extension from working. This fix simply changes the headers to match a request made from the latest Safari on Mac, which realistically should not be blocked in the same way by Brainscape. 

This addresses issue #13. 